### PR TITLE
Changed Fortran data output, fixed fortran plotting, disabled show()

### DIFF
--- a/miniapp/serial/cxx/plotting.py
+++ b/miniapp/serial/cxx/plotting.py
@@ -34,4 +34,4 @@ C=pl.contour(X, Y, data.reshape(res_x, res_y), N, colors='black', linewidth=.5)
 
 pl.clabel(C, inline=1)
 pl.savefig("output.png", dpi=72)
-pl.show()
+#pl.show()

--- a/miniapp/serial/fortran/main.f90
+++ b/miniapp/serial/fortran/main.f90
@@ -37,6 +37,7 @@ program diffusion_serial
     integer :: iseed(80), nseed
     integer :: flops_total
     integer :: output
+    integer :: reclen
 
     logical :: converged, cg_converged
     logical :: verbose_output
@@ -162,9 +163,14 @@ program diffusion_serial
     ! write final solution to BOV file for visualization
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ! binary data
+
+
     output=20
-    open(unit=output, file='output.bin', status='replace', form='unformatted')
-    write(output) x_new
+
+
+    INQUIRE(iolength=reclen) x_new
+    open(unit=output, file='output.bin', status='replace', form='unformatted',ACCESS = 'DIRECT',RECL=reclen)                               
+    write(output,REC=1) x_new
     close(output)
     ! metadata
     open (unit=output, file='output.bov', status='replace')

--- a/miniapp/serial/fortran/plotting.py
+++ b/miniapp/serial/fortran/plotting.py
@@ -18,8 +18,8 @@ headerfile.close()
 
 rawFilename = header[1].split()[1]
 
-res_x = int(header[2].split()[1][:-1]) # remove the ',' at end of string
-res_y = int(header[2].split()[2][:-1]) # remove the ',' at end of string
+res_x = int(header[2].split()[1][:]) # remove the ',' at end of string
+res_y = int(header[2].split()[2][:]) # remove the ',' at end of string
 
 data = np.fromfile(rawFilename, dtype=np.double, count=-1, sep='')
 assert data.shape[0] == res_x * res_y, "raw data array does not match the resolution in the header"
@@ -34,4 +34,4 @@ C=pl.contour(X, Y, data.reshape(res_x, res_y), N, colors='black', linewidth=.5)
 
 pl.clabel(C, inline=1)
 pl.savefig("output.png", dpi=72)
-pl.show()
+#pl.show()


### PR DESCRIPTION
Changed Fortran data output
--Removed the additional data from the raw binary
Fixed fortran plotting python script
--The metadata file is wrongly read due to fortran additional padding in the output
disabled show() …
--Due to slow connection, just save the png
